### PR TITLE
add make target for IAM role creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,3 +37,8 @@ static-check:
 
 generate:
 	$(GO_GENERATE) $(ALLFILE)
+
+SETUP_DIR=./cmd/setup
+
+create-iam-role:
+	$(GO_RUN) $(SETUP_DIR) create-iam-role

--- a/cmd/setup/iam.go
+++ b/cmd/setup/iam.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/aws-sdk-go-v2/service/iam/types"
+)
+
+const (
+	defaultRoleName           = "create-thumbnails-lambda-role"
+	defaultBucketNameOriginal = "original.images.mububoki"
+	defaultBucketNameThumbnail = "thumbnail.images.mububoki"
+	lambdaBasicExecutionRoleARN = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+	s3PolicyName               = "create-thumbnails-s3-access"
+)
+
+type trustPolicy struct {
+	Version   string            `json:"Version"`
+	Statement []trustStatement  `json:"Statement"`
+}
+
+type trustStatement struct {
+	Effect    string          `json:"Effect"`
+	Principal trustPrincipal  `json:"Principal"`
+	Action    string          `json:"Action"`
+}
+
+type trustPrincipal struct {
+	Service string `json:"Service"`
+}
+
+type s3Policy struct {
+	Version   string        `json:"Version"`
+	Statement []s3Statement `json:"Statement"`
+}
+
+type s3Statement struct {
+	Effect   string   `json:"Effect"`
+	Action   []string `json:"Action"`
+	Resource string   `json:"Resource"`
+}
+
+func envOrDefault(key, defaultValue string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return defaultValue
+}
+
+func createIAMRole() error {
+	ctx := context.Background()
+
+	cfg, err := config.LoadDefaultConfig(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to LoadDefaultConfig: %w", err)
+	}
+
+	client := iam.NewFromConfig(cfg)
+	roleName := envOrDefault("LAMBDA_ROLE_NAME", defaultRoleName)
+	bucketOriginal := envOrDefault("OBJECT_BUCKET_NAME_ORIGINAL", defaultBucketNameOriginal)
+	bucketThumbnail := envOrDefault("OBJECT_BUCKET_NAME_THUMBNAIL", defaultBucketNameThumbnail)
+
+	// Create trust policy for Lambda
+	tp := trustPolicy{
+		Version: "2012-10-17",
+		Statement: []trustStatement{
+			{
+				Effect:    "Allow",
+				Principal: trustPrincipal{Service: "lambda.amazonaws.com"},
+				Action:    "sts:AssumeRole",
+			},
+		},
+	}
+	trustPolicyJSON, err := json.Marshal(tp)
+	if err != nil {
+		return fmt.Errorf("failed to marshal trust policy: %w", err)
+	}
+
+	// Create IAM role
+	createRoleOutput, err := client.CreateRole(ctx, &iam.CreateRoleInput{
+		RoleName:                 aws.String(roleName),
+		AssumeRolePolicyDocument: aws.String(string(trustPolicyJSON)),
+		Tags: []types.Tag{
+			{Key: aws.String("Project"), Value: aws.String("create-thumbnails-lambda")},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to CreateRole: %w", err)
+	}
+
+	fmt.Printf("created role: %s\n", *createRoleOutput.Role.Arn)
+
+	// Attach AWSLambdaBasicExecutionRole managed policy
+	if _, err := client.AttachRolePolicy(ctx, &iam.AttachRolePolicyInput{
+		RoleName:  aws.String(roleName),
+		PolicyArn: aws.String(lambdaBasicExecutionRoleARN),
+	}); err != nil {
+		return fmt.Errorf("failed to AttachRolePolicy: %w", err)
+	}
+
+	fmt.Println("attached AWSLambdaBasicExecutionRole")
+
+	// Create and attach inline policy for S3 access
+	sp := s3Policy{
+		Version: "2012-10-17",
+		Statement: []s3Statement{
+			{
+				Effect:   "Allow",
+				Action:   []string{"s3:GetObject"},
+				Resource: fmt.Sprintf("arn:aws:s3:::%s/*", bucketOriginal),
+			},
+			{
+				Effect:   "Allow",
+				Action:   []string{"s3:PutObject"},
+				Resource: fmt.Sprintf("arn:aws:s3:::%s/*", bucketThumbnail),
+			},
+		},
+	}
+	s3PolicyJSON, err := json.Marshal(sp)
+	if err != nil {
+		return fmt.Errorf("failed to marshal s3 policy: %w", err)
+	}
+
+	if _, err := client.PutRolePolicy(ctx, &iam.PutRolePolicyInput{
+		RoleName:       aws.String(roleName),
+		PolicyName:     aws.String(s3PolicyName),
+		PolicyDocument: aws.String(string(s3PolicyJSON)),
+	}); err != nil {
+		return fmt.Errorf("failed to PutRolePolicy: %w", err)
+	}
+
+	fmt.Println("attached S3 access policy")
+	fmt.Printf("role ARN: %s\n", *createRoleOutput.Role.Arn)
+
+	return nil
+}

--- a/cmd/setup/main.go
+++ b/cmd/setup/main.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: setup <action>")
+		fmt.Fprintln(os.Stderr, "actions: create-iam-role")
+		os.Exit(1)
+	}
+
+	var err error
+	switch os.Args[1] {
+	case "create-iam-role":
+		err = createIAMRole()
+	default:
+		fmt.Fprintf(os.Stderr, "unknown action: %s\n", os.Args[1])
+		os.Exit(1)
+	}
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %s\n", err)
+		os.Exit(1)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/aws/aws-lambda-go v1.54.0
 	github.com/aws/aws-sdk-go-v2 v1.41.5
 	github.com/aws/aws-sdk-go-v2/config v1.32.14
+	github.com/aws/aws-sdk-go-v2/service/iam v1.53.7
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.99.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/mububoki/graffiti v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6 h1:qYQ4pzQ2Oz6WpQ8T3HvGHnZydA72
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6/go.mod h1:O3h0IK87yXci+kg6flUKzJnWeziQUKciKrLjcatSNcY=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.22 h1:rWyie/PxDRIdhNf4DzRk0lvjVOqFJuNnO8WwaIRVxzQ=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.22/go.mod h1:zd/JsJ4P7oGfUhXn1VyLqaRZwPmZwg44Jf2dS84Dm3Y=
+github.com/aws/aws-sdk-go-v2/service/iam v1.53.7 h1:n9YLiWtX3+6pTLZWvRJmtq5JIB9NA/KFelyCg5fOlTU=
+github.com/aws/aws-sdk-go-v2/service/iam v1.53.7/go.mod h1:sP46Vo6MeJcM4s0ZXcG2PFmfiSyixhIuC/74W52yKuk=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.7 h1:5EniKhLZe4xzL7a+fU3C2tfUN4nWIqlLesfrjkuPFTY=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.7/go.mod h1:x0nZssQ3qZSnIcePWLvcoFisRXJzcTVvYpAAdYX8+GI=
 github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.13 h1:JRaIgADQS/U6uXDqlPiefP32yXTda7Kqfx+LgspooZM=


### PR DESCRIPTION
closes #6

## Summary

- add `cmd/setup/` CLI tool as unified infrastructure management tool
- implement `create-iam-role` action using aws-sdk-go-v2
  - creates Lambda execution role with trust policy
  - attaches `AWSLambdaBasicExecutionRole` managed policy
  - attaches inline S3 read/write policy for source/thumbnail buckets
- add `make create-iam-role` target

## Test plan

- [x] `go build ./cmd/setup/` succeeds
- [x] `go vet ./...` no errors
- [x] `go test ./...` all pass
- [ ] `make create-iam-role` with valid AWS credentials