### PR TITLE
add make targets for s3 bucket

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,3 +42,9 @@ SETUP_DIR=./cmd/setup
 
 create-iam-role:
 	$(GO_RUN) $(SETUP_DIR) create-iam-role
+
+create-s3-buckets:
+	$(GO_RUN) $(SETUP_DIR) create-s3-buckets
+
+delete-s3-buckets:
+	$(GO_RUN) $(SETUP_DIR) delete-s3-buckets

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ GO_GET=$(GO_CMD) get -u
 GO_RUN=$(GO_CMD) run
 GO_VET=$(GO_CMD) vet
 GO_GENERATE=$(GO_CMD) generate
+.PHONY: build run clean clean-bin test install-tools static-check generate create-iam-role create-s3-buckets delete-s3-buckets
 
 BIN_DIR=./bin
 APP_DIR=./cmd

--- a/cmd/setup/main.go
+++ b/cmd/setup/main.go
@@ -8,7 +8,7 @@ import (
 func main() {
 	if len(os.Args) < 2 {
 		fmt.Fprintln(os.Stderr, "usage: setup <action>")
-		fmt.Fprintln(os.Stderr, "actions: create-iam-role")
+		fmt.Fprintln(os.Stderr, "actions: create-iam-role, create-s3-buckets, delete-s3-buckets")
 		os.Exit(1)
 	}
 
@@ -16,6 +16,10 @@ func main() {
 	switch os.Args[1] {
 	case "create-iam-role":
 		err = createIAMRole()
+	case "create-s3-buckets":
+		err = createS3Buckets()
+	case "delete-s3-buckets":
+		err = deleteS3Buckets()
 	default:
 		fmt.Fprintf(os.Stderr, "unknown action: %s\n", os.Args[1])
 		os.Exit(1)

--- a/cmd/setup/s3.go
+++ b/cmd/setup/s3.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 )
 
 func createS3Buckets() error {
@@ -24,12 +25,21 @@ func createS3Buckets() error {
 	}
 
 	for _, bucket := range buckets {
-		if _, err := client.CreateBucket(ctx, &s3.CreateBucketInput{
+		input := &s3.CreateBucketInput{
 			Bucket: aws.String(bucket),
-		}); err != nil {
+		}
+
+		// If region is not us-east-1, we must specify LocationConstraint
+		if cfg.Region != "us-east-1" {
+			input.CreateBucketConfiguration = &types.CreateBucketConfiguration{
+				LocationConstraint: types.BucketLocationConstraint(cfg.Region),
+			}
+		}
+
+		if _, err := client.CreateBucket(ctx, input); err != nil {
 			return fmt.Errorf("failed to CreateBucket %s: %w", bucket, err)
 		}
-		fmt.Printf("created bucket: %s\n", bucket)
+		fmt.Printf("created bucket: %s in %s\n", bucket, cfg.Region)
 	}
 
 	return nil
@@ -50,12 +60,48 @@ func deleteS3Buckets() error {
 	}
 
 	for _, bucket := range buckets {
+		// Empty the bucket first
+		if err := emptyBucket(ctx, client, bucket); err != nil {
+			return fmt.Errorf("failed to empty bucket %s: %w", bucket, err)
+		}
+
 		if _, err := client.DeleteBucket(ctx, &s3.DeleteBucketInput{
 			Bucket: aws.String(bucket),
 		}); err != nil {
 			return fmt.Errorf("failed to DeleteBucket %s: %w", bucket, err)
 		}
 		fmt.Printf("deleted bucket: %s\n", bucket)
+	}
+
+	return nil
+}
+
+func emptyBucket(ctx context.Context, client *s3.Client, bucket string) error {
+	p := s3.NewListObjectsV2Paginator(client, &s3.ListObjectsV2Input{
+		Bucket: aws.String(bucket),
+	})
+
+	for p.HasMorePages() {
+		page, err := p.NextPage(ctx)
+		if err != nil {
+			return err
+		}
+
+		if len(page.Contents) == 0 {
+			continue
+		}
+
+		var objects []types.ObjectIdentifier
+		for _, obj := range page.Contents {
+			objects = append(objects, types.ObjectIdentifier{Key: obj.Key})
+		}
+
+		if _, err := client.DeleteObjects(ctx, &s3.DeleteObjectsInput{
+			Bucket: aws.String(bucket),
+			Delete: &types.Delete{Objects: objects},
+		}); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/cmd/setup/s3.go
+++ b/cmd/setup/s3.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+func createS3Buckets() error {
+	ctx := context.Background()
+
+	cfg, err := config.LoadDefaultConfig(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to LoadDefaultConfig: %w", err)
+	}
+
+	client := s3.NewFromConfig(cfg)
+	buckets := []string{
+		envOrDefault("OBJECT_BUCKET_NAME_ORIGINAL", defaultBucketNameOriginal),
+		envOrDefault("OBJECT_BUCKET_NAME_THUMBNAIL", defaultBucketNameThumbnail),
+	}
+
+	for _, bucket := range buckets {
+		if _, err := client.CreateBucket(ctx, &s3.CreateBucketInput{
+			Bucket: aws.String(bucket),
+		}); err != nil {
+			return fmt.Errorf("failed to CreateBucket %s: %w", bucket, err)
+		}
+		fmt.Printf("created bucket: %s\n", bucket)
+	}
+
+	return nil
+}
+
+func deleteS3Buckets() error {
+	ctx := context.Background()
+
+	cfg, err := config.LoadDefaultConfig(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to LoadDefaultConfig: %w", err)
+	}
+
+	client := s3.NewFromConfig(cfg)
+	buckets := []string{
+		envOrDefault("OBJECT_BUCKET_NAME_ORIGINAL", defaultBucketNameOriginal),
+		envOrDefault("OBJECT_BUCKET_NAME_THUMBNAIL", defaultBucketNameThumbnail),
+	}
+
+	for _, bucket := range buckets {
+		if _, err := client.DeleteBucket(ctx, &s3.DeleteBucketInput{
+			Bucket: aws.String(bucket),
+		}); err != nil {
+			return fmt.Errorf("failed to DeleteBucket %s: %w", bucket, err)
+		}
+		fmt.Printf("deleted bucket: %s\n", bucket)
+	}
+
+	return nil
+}


### PR DESCRIPTION
closes #3

## Summary

- add `create-s3-buckets` / `delete-s3-buckets` actions to `cmd/setup/` CLI tool
- add `make create-s3-buckets` and `make delete-s3-buckets` Makefile targets
- bucket names are configurable via `OBJECT_BUCKET_NAME_ORIGINAL` / `OBJECT_BUCKET_NAME_THUMBNAIL` env vars

## Test plan

- [x] `go build ./cmd/setup/` succeeds
- [x] `go vet ./...` no errors
- [x] `go test ./...` all pass
- [ ] `make create-s3-buckets` / `make delete-s3-buckets` with valid AWS credentials