### PR TITLE
add make targets for lambda function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ GO_GET=$(GO_CMD) get -u
 GO_RUN=$(GO_CMD) run
 GO_VET=$(GO_CMD) vet
 GO_GENERATE=$(GO_CMD) generate
-.PHONY: build run clean clean-bin test install-tools static-check generate create-iam-role create-s3-buckets delete-s3-buckets
+.PHONY: build run clean clean-bin test install-tools static-check generate create-iam-role create-s3-buckets delete-s3-buckets build-lambda-function zip-lambda-function create-lambda-function update-lambda-function
 
 BIN_DIR=./bin
 APP_DIR=./cmd
@@ -49,3 +49,15 @@ create-s3-buckets:
 
 delete-s3-buckets:
 	$(GO_RUN) $(SETUP_DIR) delete-s3-buckets
+
+build-lambda-function: clean-bin
+	GOOS=linux GOARCH=arm64 CGO_ENABLED=0 $(GO_BUILD) -tags lambda.norpc -o $(BIN_DIR)/bootstrap $(MAIN_GO)
+
+zip-lambda-function: build-lambda-function
+	cd $(BIN_DIR) && zip function.zip bootstrap
+
+create-lambda-function:
+	$(GO_RUN) $(SETUP_DIR) create-lambda-function
+
+update-lambda-function:
+	$(GO_RUN) $(SETUP_DIR) update-lambda-function

--- a/cmd/setup/config.go
+++ b/cmd/setup/config.go
@@ -1,0 +1,45 @@
+package main
+
+import "os"
+
+const (
+	defaultBucketNameOriginal   = "original.images.mububoki"
+	defaultBucketNameThumbnail  = "thumbnail.images.mububoki"
+	defaultFunctionName         = "create-thumbnails-lambda"
+	defaultRoleName             = "create-thumbnails-lambda-role"
+	lambdaBasicExecutionRoleARN = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+	s3PolicyName                = "create-thumbnails-s3-access"
+)
+
+type trustPolicy struct {
+	Version   string           `json:"Version"`
+	Statement []trustStatement `json:"Statement"`
+}
+
+type trustStatement struct {
+	Effect    string         `json:"Effect"`
+	Principal trustPrincipal `json:"Principal"`
+	Action    string         `json:"Action"`
+}
+
+type trustPrincipal struct {
+	Service string `json:"Service"`
+}
+
+type s3Policy struct {
+	Version   string        `json:"Version"`
+	Statement []s3Statement `json:"Statement"`
+}
+
+type s3Statement struct {
+	Effect   string   `json:"Effect"`
+	Action   []string `json:"Action"`
+	Resource string   `json:"Resource"`
+}
+
+func envOrDefault(key, defaultValue string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return defaultValue
+}

--- a/cmd/setup/iam.go
+++ b/cmd/setup/iam.go
@@ -4,54 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/aws/aws-sdk-go-v2/service/iam/types"
 )
-
-const (
-	defaultRoleName           = "create-thumbnails-lambda-role"
-	defaultBucketNameOriginal = "original.images.mububoki"
-	defaultBucketNameThumbnail = "thumbnail.images.mububoki"
-	lambdaBasicExecutionRoleARN = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-	s3PolicyName               = "create-thumbnails-s3-access"
-)
-
-type trustPolicy struct {
-	Version   string            `json:"Version"`
-	Statement []trustStatement  `json:"Statement"`
-}
-
-type trustStatement struct {
-	Effect    string          `json:"Effect"`
-	Principal trustPrincipal  `json:"Principal"`
-	Action    string          `json:"Action"`
-}
-
-type trustPrincipal struct {
-	Service string `json:"Service"`
-}
-
-type s3Policy struct {
-	Version   string        `json:"Version"`
-	Statement []s3Statement `json:"Statement"`
-}
-
-type s3Statement struct {
-	Effect   string   `json:"Effect"`
-	Action   []string `json:"Action"`
-	Resource string   `json:"Resource"`
-}
-
-func envOrDefault(key, defaultValue string) string {
-	if v := os.Getenv(key); v != "" {
-		return v
-	}
-	return defaultValue
-}
 
 func createIAMRole() error {
 	ctx := context.Background()

--- a/cmd/setup/lambda.go
+++ b/cmd/setup/lambda.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/aws-sdk-go-v2/service/lambda"
+	lambdatypes "github.com/aws/aws-sdk-go-v2/service/lambda/types"
+)
+
+const (
+	defaultLambdaZipPath    = "bin/function.zip"
+	defaultLambdaTimeout    = 30
+	defaultLambdaMemorySize = 256
+)
+
+func createLambdaFunction() error {
+	ctx := context.Background()
+
+	cfg, err := config.LoadDefaultConfig(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to LoadDefaultConfig: %w", err)
+	}
+
+	functionName := envOrDefault("LAMBDA_FUNCTION_NAME", defaultFunctionName)
+	roleName := envOrDefault("LAMBDA_ROLE_NAME", defaultRoleName)
+	zipPath := envOrDefault("LAMBDA_ZIP_PATH", defaultLambdaZipPath)
+	bucketOriginal := envOrDefault("OBJECT_BUCKET_NAME_ORIGINAL", defaultBucketNameOriginal)
+	bucketThumbnail := envOrDefault("OBJECT_BUCKET_NAME_THUMBNAIL", defaultBucketNameThumbnail)
+
+	roleARN, err := getRoleARN(ctx, cfg, roleName)
+	if err != nil {
+		return err
+	}
+
+	zipBytes, err := os.ReadFile(zipPath)
+	if err != nil {
+		return fmt.Errorf("failed to read zip %s: %w", zipPath, err)
+	}
+
+	client := lambda.NewFromConfig(cfg)
+	out, err := client.CreateFunction(ctx, &lambda.CreateFunctionInput{
+		FunctionName:  aws.String(functionName),
+		Role:          aws.String(roleARN),
+		Runtime:       lambdatypes.RuntimeProvidedal2023,
+		Handler:       aws.String("bootstrap"),
+		Code:          &lambdatypes.FunctionCode{ZipFile: zipBytes},
+		Architectures: []lambdatypes.Architecture{lambdatypes.ArchitectureArm64},
+		Timeout:       aws.Int32(defaultLambdaTimeout),
+		MemorySize:    aws.Int32(defaultLambdaMemorySize),
+		Environment: &lambdatypes.Environment{
+			Variables: map[string]string{
+				"OBJECT_BUCKET_NAME_ORIGINAL":  bucketOriginal,
+				"OBJECT_BUCKET_NAME_THUMBNAIL": bucketThumbnail,
+			},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to CreateFunction: %w", err)
+	}
+
+	fmt.Printf("created function: %s\n", aws.ToString(out.FunctionArn))
+	return nil
+}
+
+func updateLambdaFunction() error {
+	ctx := context.Background()
+
+	cfg, err := config.LoadDefaultConfig(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to LoadDefaultConfig: %w", err)
+	}
+
+	functionName := envOrDefault("LAMBDA_FUNCTION_NAME", defaultFunctionName)
+	zipPath := envOrDefault("LAMBDA_ZIP_PATH", defaultLambdaZipPath)
+
+	zipBytes, err := os.ReadFile(zipPath)
+	if err != nil {
+		return fmt.Errorf("failed to read zip %s: %w", zipPath, err)
+	}
+
+	client := lambda.NewFromConfig(cfg)
+	out, err := client.UpdateFunctionCode(ctx, &lambda.UpdateFunctionCodeInput{
+		FunctionName: aws.String(functionName),
+		ZipFile:      zipBytes,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to UpdateFunctionCode: %w", err)
+	}
+
+	fmt.Printf("updated function: %s\n", aws.ToString(out.FunctionArn))
+	return nil
+}
+
+func getRoleARN(ctx context.Context, cfg aws.Config, roleName string) (string, error) {
+	client := iam.NewFromConfig(cfg)
+	out, err := client.GetRole(ctx, &iam.GetRoleInput{
+		RoleName: aws.String(roleName),
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to GetRole: %w", err)
+	}
+	return aws.ToString(out.Role.Arn), nil
+}

--- a/cmd/setup/main.go
+++ b/cmd/setup/main.go
@@ -8,7 +8,7 @@ import (
 func main() {
 	if len(os.Args) < 2 {
 		fmt.Fprintln(os.Stderr, "usage: setup <action>")
-		fmt.Fprintln(os.Stderr, "actions: create-iam-role, create-s3-buckets, delete-s3-buckets")
+		fmt.Fprintln(os.Stderr, "actions: create-iam-role, create-s3-buckets, delete-s3-buckets, create-lambda-function, update-lambda-function")
 		os.Exit(1)
 	}
 
@@ -20,6 +20,10 @@ func main() {
 		err = createS3Buckets()
 	case "delete-s3-buckets":
 		err = deleteS3Buckets()
+	case "create-lambda-function":
+		err = createLambdaFunction()
+	case "update-lambda-function":
+		err = updateLambdaFunction()
 	default:
 		fmt.Fprintf(os.Stderr, "unknown action: %s\n", os.Args[1])
 		os.Exit(1)

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/aws/aws-lambda-go v1.54.0
-	github.com/aws/aws-sdk-go-v2 v1.41.5
+	github.com/aws/aws-sdk-go-v2 v1.41.7
 	github.com/aws/aws-sdk-go-v2/config v1.32.14
 	github.com/aws/aws-sdk-go-v2/service/iam v1.53.7
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.99.0
@@ -16,22 +16,23 @@ require (
 )
 
 require (
-	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8 // indirect
+	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.14 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.21 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.22 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.7 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.13 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.21 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.21 // indirect
+	github.com/aws/aws-sdk-go-v2/service/lambda v1.90.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.15 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.19 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.10 // indirect
-	github.com/aws/smithy-go v1.24.2 // indirect
+	github.com/aws/smithy-go v1.25.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,12 @@ github.com/aws/aws-lambda-go v1.54.0 h1:EGYpdyRGF88xszqlGcBewz811mJeRS+maNlLZXFh
 github.com/aws/aws-lambda-go v1.54.0/go.mod h1:dpMpZgvWx5vuQJfBt0zqBha60q7Dd7RfgJv23DymV8A=
 github.com/aws/aws-sdk-go-v2 v1.41.5 h1:dj5kopbwUsVUVFgO4Fi5BIT3t4WyqIDjGKCangnV/yY=
 github.com/aws/aws-sdk-go-v2 v1.41.5/go.mod h1:mwsPRE8ceUUpiTgF7QmQIJ7lgsKUPQOUl3o72QBrE1o=
+github.com/aws/aws-sdk-go-v2 v1.41.7 h1:DWpAJt66FmnnaRIOT/8ASTucrvuDPZASqhhLey6tLY8=
+github.com/aws/aws-sdk-go-v2 v1.41.7/go.mod h1:4LAfZOPHNVNQEckOACQx60Y8pSRjIkNZQz1w92xpMJc=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8 h1:eBMB84YGghSocM7PsjmmPffTa+1FBUeNvGvFou6V/4o=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8/go.mod h1:lyw7GFp3qENLh7kwzf7iMzAxDn+NzjXEAGjKS2UOKqI=
+github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10 h1:gx1AwW1Iyk9Z9dD9F4akX5gnN3QZwUB20GGKH/I+Rho=
+github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10/go.mod h1:qqY157uZoqm5OXq/amuaBJyC9hgBCBQnsaWnPe905GY=
 github.com/aws/aws-sdk-go-v2/config v1.32.14 h1:opVIRo/ZbbI8OIqSOKmpFaY7IwfFUOCCXBsUpJOwDdI=
 github.com/aws/aws-sdk-go-v2/config v1.32.14/go.mod h1:U4/V0uKxh0Tl5sxmCBZ3AecYny4UNlVmObYjKuuaiOo=
 github.com/aws/aws-sdk-go-v2/credentials v1.19.14 h1:n+UcGWAIZHkXzYt87uMFBv/l8THYELoX6gVcUvgl6fI=
@@ -12,8 +16,12 @@ github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21 h1:NUS3K4BTDArQqNu2ih7yeD
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21/go.mod h1:YWNWJQNjKigKY1RHVJCuupeWDrrHjRqHm0N9rdrWzYI=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21 h1:Rgg6wvjjtX8bNHcvi9OnXWwcE0a2vGpbwmtICOsvcf4=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21/go.mod h1:A/kJFst/nm//cyqonihbdpQZwiUhhzpqTsdbhDdRF9c=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23 h1:GpT/TrnBYuE5gan2cZbTtvP+JlHsutdmlV2YfEyNde0=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23/go.mod h1:xYWD6BS9ywC5bS3sz9Xh04whO/hzK2plt2Zkyrp4JuA=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.21 h1:PEgGVtPoB6NTpPrBgqSE5hE/o47Ij9qk/SEZFbUOe9A=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.21/go.mod h1:p+hz+PRAYlY3zcpJhPwXlLC4C+kqn70WIHwnzAfs6ps=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23 h1:bpd8vxhlQi2r1hiueOw02f/duEPTMK59Q4QMAoTTtTo=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23/go.mod h1:15DfR2nw+CRHIk0tqNyifu3G1YdAOy68RftkhMDDwYk=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6 h1:qYQ4pzQ2Oz6WpQ8T3HvGHnZydA72MnLuFK9tJwmrbHw=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6/go.mod h1:O3h0IK87yXci+kg6flUKzJnWeziQUKciKrLjcatSNcY=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.22 h1:rWyie/PxDRIdhNf4DzRk0lvjVOqFJuNnO8WwaIRVxzQ=
@@ -28,6 +36,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.21 h1:c31//R3x
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.21/go.mod h1:r6+pf23ouCB718FUxaqzZdbpYFyDtehyZcmP5KL9FkA=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.21 h1:ZlvrNcHSFFWURB8avufQq9gFsheUgjVD9536obIknfM=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.21/go.mod h1:cv3TNhVrssKR0O/xxLJVRfd2oazSnZnkUeTf6ctUwfQ=
+github.com/aws/aws-sdk-go-v2/service/lambda v1.90.1 h1:odCeJgHXfQoXEWQUIzPkKvsJTWcLMsaOWowNpovPFFw=
+github.com/aws/aws-sdk-go-v2/service/lambda v1.90.1/go.mod h1:NbtJVztitG7JkuoI4GSrDUlsB32zeXqKBvXj6bUxcMo=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.99.0 h1:hlSuz394kV0vhv9drL5lhuEFbEOEP1VyQpy15qWh1Pk=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.99.0/go.mod h1:uoA43SdFwacedBfSgfFSjjCvYe8aYBS7EnU5GZ/YKMM=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.9 h1:QKZH0S178gCmFEgst8hN0mCX1KxLgHBKKY/CLqwP8lg=
@@ -40,6 +50,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.41.10 h1:p8ogvvLugcR/zLBXTXrTkj0RYBU
 github.com/aws/aws-sdk-go-v2/service/sts v1.41.10/go.mod h1:60dv0eZJfeVXfbT1tFJinbHrDfSJ2GZl4Q//OSSNAVw=
 github.com/aws/smithy-go v1.24.2 h1:FzA3bu/nt/vDvmnkg+R8Xl46gmzEDam6mZ1hzmwXFng=
 github.com/aws/smithy-go v1.24.2/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
+github.com/aws/smithy-go v1.25.1 h1:J8ERsGSU7d+aCmdQur5Txg6bVoYelvQJgtZehD12GkI=
+github.com/aws/smithy-go v1.25.1/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
closes #2

## Summary

- add `cmd/setup/lambda.go` with `create-lambda-function` / `update-lambda-function` actions
  - runtime: `provided.al2023`, architecture: `arm64`, handler: `bootstrap`
  - role ARN is resolved from IAM by `LAMBDA_ROLE_NAME` (default: `create-thumbnails-lambda-role`)
  - Lambda env vars `OBJECT_BUCKET_NAME_ORIGINAL` / `OBJECT_BUCKET_NAME_THUMBNAIL` are propagated from the host env
- add `make build-lambda-function` (cross-compile to linux/arm64 with `lambda.norpc` build tag)
- add `make zip-lambda-function` (produces `bin/function.zip` containing `bootstrap` at root)
- add `make create-lambda-function` / `make update-lambda-function`
- extract shared constants/types/helpers into `cmd/setup/config.go`
- requires `zip` CLI on the host

## Configurable env vars

- `LAMBDA_FUNCTION_NAME` (default: `create-thumbnails-lambda`)
- `LAMBDA_ROLE_NAME` (default: `create-thumbnails-lambda-role`)
- `LAMBDA_ZIP_PATH` (default: `bin/function.zip`)
- `OBJECT_BUCKET_NAME_ORIGINAL` / `OBJECT_BUCKET_NAME_THUMBNAIL`

## Test plan

- [x] `go build ./...` succeeds
- [x] `go test ./...` all pass
- [x] `make build-lambda-function` produces `bin/bootstrap` (linux/arm64)
- [x] `make zip-lambda-function` produces `bin/function.zip` with `bootstrap` at root
- [ ] `make create-lambda-function` with valid AWS credentials
- [ ] `make update-lambda-function` with valid AWS credentials