### PR TITLE
add CI workflow and documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - run: make test
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - run: make install-tools
+      - run: make static-check
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - run: make zip-lambda-function

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# Build artifacts
+/bin/
+/setup

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ GO_CMD=go
 GO_BUILD=$(GO_CMD) build
 GO_CLEAN=$(GO_CMD) clean
 GO_TEST=$(GO_CMD) test
-GO_GET=$(GO_CMD) get -u
+GO_INSTALL=$(GO_CMD) install
 GO_RUN=$(GO_CMD) run
 GO_VET=$(GO_CMD) vet
 GO_GENERATE=$(GO_CMD) generate
@@ -30,11 +30,10 @@ test:
 	$(GO_TEST) $(ALLFILE)
 
 install-tools:
-	$(GO_GET) \
-	github.com/kisielk/errcheck@latest
+	$(GO_INSTALL) github.com/kisielk/errcheck@latest
 
 static-check:
-	$(GO_VET) $(ALLFILE); errcheck $(ALLFILE)
+	$(GO_VET) $(ALLFILE) && errcheck $(ALLFILE)
 
 generate:
 	$(GO_GENERATE) $(ALLFILE)

--- a/README.md
+++ b/README.md
@@ -9,10 +9,87 @@ put them to another bucket.
 
 support: jpeg, gif, png
 
+## image limits
+
+Images that exceed any of these limits are rejected without producing a thumbnail.
+
+| limit | value |
+| :---: | :---: |
+| file size | 50 MiB |
+| width | 10000 px |
+| height | 10000 px |
+
 ## environment variables
+
+### lambda runtime
 
 | name | default value | note |
 | :---: | :---: | :--- |
 | IMAGE_RATE | 0.5 | magnification rate |
-| OBJECT_BUCKET_NAME_ORIGINAL | original.images.mububoki | Lambda will be invoked when you put images to this bucket.
+| OBJECT_BUCKET_NAME_ORIGINAL | original.images.mububoki | Lambda will be invoked when you put images to this bucket. |
 | OBJECT_BUCKET_NAME_THUMBNAIL | thumbnail.images.mububoki | Lambda puts thumbnails to this bucket. |
+
+### setup CLI (cmd/setup)
+
+| name | default value | note |
+| :---: | :---: | :--- |
+| AWS_REGION | (none) | required by AWS SDK |
+| LAMBDA_FUNCTION_NAME | create-thumbnails-lambda | Lambda function name |
+| LAMBDA_ROLE_NAME | create-thumbnails-lambda-role | IAM role name for the Lambda |
+| LAMBDA_ZIP_PATH | bin/function.zip | path to the zip artifact for create/update |
+| OBJECT_BUCKET_NAME_ORIGINAL | original.images.mububoki | source bucket name |
+| OBJECT_BUCKET_NAME_THUMBNAIL | thumbnail.images.mububoki | destination bucket name |
+
+## prerequisites
+
+- Go (version specified in `go.mod`)
+- `make`
+- `zip`
+- AWS credentials available via the standard SDK chain (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` env vars, `~/.aws/credentials`, etc.)
+
+## make targets
+
+### development
+
+| target | description |
+| :--- | :--- |
+| `make build` | build for the host OS to `bin/app` |
+| `make test` | run all tests |
+| `make install-tools` | install `errcheck` |
+| `make static-check` | `go vet` + `errcheck` |
+| `make generate` | run `go generate` |
+
+### Lambda artifact
+
+| target | description |
+| :--- | :--- |
+| `make build-lambda-function` | cross-compile to `bin/bootstrap` (linux/arm64) |
+| `make zip-lambda-function` | build then archive to `bin/function.zip` |
+
+### AWS resource setup
+
+| target | description |
+| :--- | :--- |
+| `make create-iam-role` | create the Lambda execution IAM role |
+| `make create-s3-buckets` | create source/destination S3 buckets |
+| `make delete-s3-buckets` | empty and delete source/destination S3 buckets |
+| `make create-lambda-function` | create the Lambda function from `bin/function.zip` |
+| `make update-lambda-function` | update the Lambda code from `bin/function.zip` |
+
+## deployment
+
+```sh
+export AWS_REGION=ap-northeast-1
+# AWS credentials must also be available via the SDK chain.
+
+make create-iam-role
+make create-s3-buckets
+make zip-lambda-function
+make create-lambda-function
+
+# subsequent code updates:
+make zip-lambda-function
+make update-lambda-function
+```
+
+After the Lambda is created, configure the source bucket to invoke it on `s3:ObjectCreated:*` events via the AWS Console or another tool — the setup CLI does not configure the trigger.

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.41.7
 	github.com/aws/aws-sdk-go-v2/config v1.32.14
 	github.com/aws/aws-sdk-go-v2/service/iam v1.53.7
+	github.com/aws/aws-sdk-go-v2/service/lambda v1.90.1
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.99.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/mububoki/graffiti v1.0.0
@@ -27,7 +28,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.13 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.21 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.21 // indirect
-	github.com/aws/aws-sdk-go-v2/service/lambda v1.90.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.15 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.19 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,7 @@
 github.com/aws/aws-lambda-go v1.54.0 h1:EGYpdyRGF88xszqlGcBewz811mJeRS+maNlLZXFheII=
 github.com/aws/aws-lambda-go v1.54.0/go.mod h1:dpMpZgvWx5vuQJfBt0zqBha60q7Dd7RfgJv23DymV8A=
-github.com/aws/aws-sdk-go-v2 v1.41.5 h1:dj5kopbwUsVUVFgO4Fi5BIT3t4WyqIDjGKCangnV/yY=
-github.com/aws/aws-sdk-go-v2 v1.41.5/go.mod h1:mwsPRE8ceUUpiTgF7QmQIJ7lgsKUPQOUl3o72QBrE1o=
 github.com/aws/aws-sdk-go-v2 v1.41.7 h1:DWpAJt66FmnnaRIOT/8ASTucrvuDPZASqhhLey6tLY8=
 github.com/aws/aws-sdk-go-v2 v1.41.7/go.mod h1:4LAfZOPHNVNQEckOACQx60Y8pSRjIkNZQz1w92xpMJc=
-github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8 h1:eBMB84YGghSocM7PsjmmPffTa+1FBUeNvGvFou6V/4o=
-github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8/go.mod h1:lyw7GFp3qENLh7kwzf7iMzAxDn+NzjXEAGjKS2UOKqI=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10 h1:gx1AwW1Iyk9Z9dD9F4akX5gnN3QZwUB20GGKH/I+Rho=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10/go.mod h1:qqY157uZoqm5OXq/amuaBJyC9hgBCBQnsaWnPe905GY=
 github.com/aws/aws-sdk-go-v2/config v1.32.14 h1:opVIRo/ZbbI8OIqSOKmpFaY7IwfFUOCCXBsUpJOwDdI=
@@ -14,12 +10,8 @@ github.com/aws/aws-sdk-go-v2/credentials v1.19.14 h1:n+UcGWAIZHkXzYt87uMFBv/l8TH
 github.com/aws/aws-sdk-go-v2/credentials v1.19.14/go.mod h1:cJKuyWB59Mqi0jM3nFYQRmnHVQIcgoxjEMAbLkpr62w=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21 h1:NUS3K4BTDArQqNu2ih7yeDLaS3bmHD0YndtA6UP884g=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21/go.mod h1:YWNWJQNjKigKY1RHVJCuupeWDrrHjRqHm0N9rdrWzYI=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21 h1:Rgg6wvjjtX8bNHcvi9OnXWwcE0a2vGpbwmtICOsvcf4=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21/go.mod h1:A/kJFst/nm//cyqonihbdpQZwiUhhzpqTsdbhDdRF9c=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23 h1:GpT/TrnBYuE5gan2cZbTtvP+JlHsutdmlV2YfEyNde0=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23/go.mod h1:xYWD6BS9ywC5bS3sz9Xh04whO/hzK2plt2Zkyrp4JuA=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.21 h1:PEgGVtPoB6NTpPrBgqSE5hE/o47Ij9qk/SEZFbUOe9A=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.21/go.mod h1:p+hz+PRAYlY3zcpJhPwXlLC4C+kqn70WIHwnzAfs6ps=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23 h1:bpd8vxhlQi2r1hiueOw02f/duEPTMK59Q4QMAoTTtTo=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23/go.mod h1:15DfR2nw+CRHIk0tqNyifu3G1YdAOy68RftkhMDDwYk=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6 h1:qYQ4pzQ2Oz6WpQ8T3HvGHnZydA72MnLuFK9tJwmrbHw=
@@ -48,8 +40,6 @@ github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.19 h1:dzztQ1YmfPrxdrOiuZRMF6f
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.19/go.mod h1:YO8TrYtFdl5w/4vmjL8zaBSsiNp3w0L1FfKVKenZT7w=
 github.com/aws/aws-sdk-go-v2/service/sts v1.41.10 h1:p8ogvvLugcR/zLBXTXrTkj0RYBUdErbMnAFFp12Lm/U=
 github.com/aws/aws-sdk-go-v2/service/sts v1.41.10/go.mod h1:60dv0eZJfeVXfbT1tFJinbHrDfSJ2GZl4Q//OSSNAVw=
-github.com/aws/smithy-go v1.24.2 h1:FzA3bu/nt/vDvmnkg+R8Xl46gmzEDam6mZ1hzmwXFng=
-github.com/aws/smithy-go v1.24.2/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/aws/smithy-go v1.25.1 h1:J8ERsGSU7d+aCmdQur5Txg6bVoYelvQJgtZehD12GkI=
 github.com/aws/smithy-go v1.25.1/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=


### PR DESCRIPTION
closes #8

## Summary

- add `.github/workflows/ci.yml` with `test`, `lint`, and `build` jobs (runs on push/PR to `main`, Go version follows `go.mod`)
- update `.gitignore` to exclude build artifacts (`/bin/`, `/setup`)
- rewrite `README.md`: image limits, environment variables for runtime and setup CLI, prerequisites, all `make` targets, deployment quickstart, note that the S3 trigger must be configured separately
- fix `make install-tools` to use `go install` (previously used `go get -u`, which polluted `go.mod` instead of installing the binary)
- fix `make static-check` to fail fast (`;` → `&&`) so `go vet` errors do not get swallowed
- `go mod tidy` cleans up indirect deps that the old `install-tools` left behind, and promotes `aws-sdk-go-v2/service/lambda` to direct

## Test plan

- [x] `go build ./...` succeeds
- [x] `go test ./...` all pass
- [x] `make install-tools` installs `errcheck` to `$GOPATH/bin`
- [x] `make static-check` succeeds (no errors)
- [x] `make zip-lambda-function` produces `bin/function.zip`
- [ ] CI passes on the PR